### PR TITLE
Implement recursive let bindings

### DIFF
--- a/examples/pass/functions/calling_a_rec_function_from_a_regular_function.uplp
+++ b/examples/pass/functions/calling_a_rec_function_from_a_regular_function.uplp
@@ -1,0 +1,9 @@
+-- test: check { "type": "Num", "value": 3628800 }
+
+let rec fact_rec = |n: Num| |acc: Num| 
+  if n == 0 then acc
+  else fact_rec (n - 1) (acc * n) in
+
+let fact = |n: Num| fact_rec n 1 in
+
+fact 10

--- a/examples/pass/functions/recursion_fib.uplp
+++ b/examples/pass/functions/recursion_fib.uplp
@@ -1,0 +1,6 @@
+-- test: check { "type": "Num", "value": 8 }
+
+let rec fib = |n: Num| if n == 0 then 0 
+  else if n == 1 then 1
+  else fib (n - 2) + fib (n - 1) in
+fib 6

--- a/examples/pass/functions/recursive_fact.uplp
+++ b/examples/pass/functions/recursive_fact.uplp
@@ -1,0 +1,6 @@
+-- test: check { "type": "Num", "value": 120 }
+let rec fact = |n: Num| 
+  if n == 0 then 1
+  else n * fact (n - 1) 
+in
+fact 5

--- a/examples/pass/functions/recursive_function.uplp
+++ b/examples/pass/functions/recursive_function.uplp
@@ -1,2 +1,0 @@
--- test: skip
-let fib = |n: Num| if n == 0 then 0 else n + fib (n - 1)

--- a/examples/pass/functions/tail_recursive_function.uplp
+++ b/examples/pass/functions/tail_recursive_function.uplp
@@ -1,0 +1,7 @@
+-- test: check { "type": "Num", "value": 3628800 }
+
+let rec fact_rec = |n: Num| |acc: Num| 
+  if n == 0 then acc
+  else fact_rec (n - 1) (acc * n) in
+
+fact_rec 10 1

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,7 +6,7 @@ use crate::{types::Type, values::Val};
 pub enum RawExpr {
     App(Box<RawExpr>, Box<RawExpr>),
     Lambda(RawIdent, Type, Box<RawExpr>),
-    Let(RawIdent, Box<RawExpr>, Box<RawExpr>),
+    Let(bool, RawIdent, Box<RawExpr>, Box<RawExpr>),
     Literal(Val),
     IfThenElse(Box<RawExpr>, Box<RawExpr>, Box<RawExpr>),
     Var(RawIdent),
@@ -18,7 +18,10 @@ impl Debug for RawExpr {
         match self {
             RawExpr::App(fnc, a) => write!(f, "({fnc:?} {a:?})"),
             RawExpr::Lambda(i, ty, body) => write!(f, "(|{i:?}: {ty:?}| {body:?})"),
-            RawExpr::Let(i, bnd, body) => write!(f, "(let {i:?} = {bnd:?} in {body:?})"),
+            RawExpr::Let(rec, i, bnd, body) => {
+                let rec_txt = if *rec { "rec " } else { "" };
+                write!(f, "(let {rec_txt}{i:?} = {bnd:?} in {body:?})")
+            },
             RawExpr::Literal(v) => write!(f, "{v}"),
             RawExpr::IfThenElse(cond, then, els) => {
                 write!(f, "if {cond:?} then {then:?} else {els:?}")
@@ -32,8 +35,8 @@ impl Debug for RawExpr {
 #[derive(PartialEq)]
 pub enum Expr {
     App(Box<Expr>, Box<Expr>),
-    Lambda(Type, Box<Expr>),
-    Let(Box<Expr>, Box<Expr>),
+    Lambda(Option<Type>, Box<Expr>),
+    Let(bool, Box<Expr>, Box<Expr>),
     Literal(Val),
     IfThenElse(Box<Expr>, Box<Expr>, Box<Expr>),
     Var(usize),
@@ -45,11 +48,14 @@ impl Debug for Expr {
         match self {
             Expr::App(fnc, a) => write!(f, "{fnc:?} {a:?}"),
             Expr::Lambda(ty, body) => write!(f, "|{ty:?}| {body:?}"),
-            Expr::Let(bnd, body) => write!(f, "let {bnd:?} in {body:?}"),
+            Expr::Let(rec, bnd, body) => {
+                let rec = if *rec { "rec " } else { "" };
+                write!(f, "let {rec}{bnd:?} in {body:?}")
+            },
             Expr::Literal(v) => write!(f, "{v}"),
             Expr::IfThenElse(cond, thn, els) => write!(f, "if {cond:?} then {thn:?} else {els:?}"),
             Expr::Op(l, op, r) => write!(f, "({l:?} {op:?} {r:?})"),
-            Expr::Var(i) => write!(f, "{i:?}"),
+            Expr::Var(i) => write!(f, "e[{i:?}]"),
         }
     }
 }
@@ -94,7 +100,7 @@ impl Debug for BinaryOp {
             BinaryOp::Div => "/",
             BinaryOp::Add => "+",
             BinaryOp::Sub => "-",
-            BinaryOp::Eq => "*",
+            BinaryOp::Eq => "==",
             BinaryOp::And => "&&",
         };
         write!(f, "{}", w)

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,49 +5,33 @@ use std::{cell::RefCell, rc::Rc};
 #[derive(Debug, PartialEq)]
 pub struct Env<T> {
     /// The current environment layer, in reverse order.
-    current: Rc<Vec<T>>,
+    current: Rc<RefCell<Vec<T>>>,
     /// Pointers to each of the previous environment layers.
     previous: RefCell<Option<Rc<Env<T>>>>,
 }
 
 impl<T> Clone for Env<T> {
     fn clone(&self) -> Self {
-        if !(self.current.is_empty() || self.was_cloned()) {
+        if !self.current.borrow().is_empty() && !self.was_cloned() {
             self.previous.replace_with(|old| {
                 Some(Rc::new(Env {
-                    current: self.current.clone(),
+                    current: Rc::new(RefCell::new(self.current.take())),
                     previous: RefCell::new(old.clone()),
                 }))
             });
         }
         Self {
-            current: Rc::new(Vec::new()),
+            current: Rc::new(RefCell::new(Vec::new())),
             previous: self.previous.clone(),
         }
     }
 }
 
-impl<T: Clone + core::fmt::Debug> Env<T> {
+impl<T: Clone> Env<T> {
     pub fn lookup(&self, n: usize) -> Option<T> {
-        // n is the de Bruijn index of the variable, which means we need to
-        // count backwards from the end of the environment. for example,
-        // if n is 1, we need to take the second-to-last element.
-        //
-        // the complication here is that n might be in a previous layer, so
-        // we calculate what the index of n would be were it in the current
-        // layer, using checked arithmetic. if we get None, then we underflowed
-        // so we need to check the next layer.
-        let current_len = self.current.len();
-        let poss_idx = current_len.checked_sub(1).and_then(|i| i.checked_sub(n));
-
-        if let Some(idx) = poss_idx {
-            self.current.get(idx).cloned()
-        } else {
-            self.previous
-                .borrow()
-                .as_ref()
-                .and_then(|e| e.lookup(n - current_len))
-        }
+        self.do_at_position(n, |t| {
+            t.clone()
+        })
     }
 }
 
@@ -60,7 +44,7 @@ impl<T> Default for Env<T> {
 impl<T> Env<T> {
     /// Create a new (empty) environment.
     pub fn new() -> Self {
-        let current = Rc::new(Vec::new());
+        let current = Rc::new(RefCell::new(Vec::new()));
         let previous = RefCell::new(None);
         Env { current, previous }
     }
@@ -68,17 +52,69 @@ impl<T> Env<T> {
     /// Add a new binding to the environment.
     pub fn bind(&mut self, t: T) {
         if self.was_cloned() {
-            self.current = Rc::new(Vec::new());
+            self.current = Rc::new(RefCell::new(Vec::new()));
         }
-        Rc::get_mut(&mut self.current).unwrap().push(t)
+        self.current.borrow_mut().push(t)
     }
 
-    /// Pop the latest binding from the environment.
+    /// Pop the latest binding from this environment.
     pub fn unbind(&mut self) {
-        Rc::get_mut(&mut self.current).unwrap().pop();
+        self.current.borrow_mut().pop();
     }
 
     fn was_cloned(&self) -> bool {
         Rc::strong_count(&self.current) > 1
+    }
+
+    fn position_of_first_match(&self, pred: &impl Fn(&T) -> bool) -> Option<usize> {
+        let pos = self.current.borrow().iter().rev().position(pred);
+        pos.or_else(|| {
+            let current_len = self.current.borrow().len();
+            self.previous
+                .borrow()
+                .as_deref()
+                .and_then(|prev| prev.position_of_first_match(pred))
+                .map(|n| n + current_len)
+        })
+    }
+
+    fn do_at_position<F, U>(&self, n: usize, f: F) -> Option<U> where F: FnOnce(&mut T) -> U {
+        // n is the de Bruijn index of the variable, which means we need to
+        // count backwards from the end of the environment. for example,
+        // if n is 1, we need to take the second-to-last element.
+        //
+        // the complication here is that n might be in a previous layer, so
+        // we calculate what the index of n would be were it in the current
+        // layer, using checked arithmetic. if we get None, then we underflowed
+        // so we need to check the next layer.
+        // let current_len = self.current.borrow().len();
+        // let poss_idx = current_len.checked_sub(1).and_then(|i| i.checked_sub(n));
+        let current_len = self.current.borrow().len();
+        let poss_idx = current_len.checked_sub(1).and_then(|i| i.checked_sub(n));
+        if let Some(idx) = poss_idx {
+            Some(f(&mut self.current.borrow_mut()[idx]))
+        } else {
+            let prev = self.previous.borrow();
+            if let Some(prev) = prev.as_ref() {
+                prev.do_at_position(n - current_len, f)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+impl <T: Clone> Env<RefCell<T>> {
+    pub fn update_first_match(&mut self, new_val: T, pred: impl Fn(&T) -> bool) {
+        let pos = self.position_of_first_match(&|r| pred(&r.borrow()));
+        if let Some(pos) = pos {
+            self.update(pos, new_val);
+        }
+    }
+
+    pub fn update(&self, n: usize, new_val: T) {
+        self.do_at_position(n, |r| {
+            r.replace(new_val.clone());
+        });
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -87,8 +87,6 @@ impl<T> Env<T> {
         // we calculate what the index of n would be were it in the current
         // layer, using checked arithmetic. if we get None, then we underflowed
         // so we need to check the next layer.
-        // let current_len = self.current.borrow().len();
-        // let poss_idx = current_len.checked_sub(1).and_then(|i| i.checked_sub(n));
         let current_len = self.current.borrow().len();
         let poss_idx = current_len.checked_sub(1).and_then(|i| i.checked_sub(n));
         if let Some(idx) = poss_idx {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub fn check_types(input: &str) -> Result<Type, Error> {
     let mut type_checker = types::TypeChecker::new();
 
     let expr = parse_and_scope_check(input)?;
-    let typ = type_checker.check(&expr)?;
+    let typ = type_checker.infer(&expr)?;
     Ok(typ)
 }
 
@@ -36,7 +36,7 @@ pub fn evaluate(input: &str) -> Result<values::Val, error::Error> {
     let expr = parse_and_scope_check(input)?;
 
     let mut type_checker = TypeChecker::new();
-    let _ = type_checker.check(&expr)?;
+    let _ = type_checker.infer(&expr)?;
 
     let compiler = vm::Compiler::new();
     let code = compiler.compile(&expr);

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -11,7 +11,8 @@ pub Uplp = Expr;
 
 Expr: Box<RawExpr> = {
     InfixExpr,
-    "let" <Ident> "=" <Expr> "in" <Expr> => Box::new(RawExpr::Let(<>)),
+    "let" <rec: "rec"?> <ident: Ident> "=" <bnd: Expr> "in" <body: Expr> =>
+        Box::new(RawExpr::Let(rec.is_some(), ident, bnd, body)),
     "|" <Ident> ":" <Type> "|" <Expr> => Box::new(RawExpr::Lambda(<>)),
     "if" <Expr> "then" <Expr> "else" <Expr> => Box::new(RawExpr::IfThenElse(<>)),
 }

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -26,13 +26,19 @@ impl ScopeChecker {
                 self.idents.push(ident);
                 let body = Box::new(self.check(*body)?);
                 self.idents.pop();
-                Ok(Expr::Lambda(ty, body))
+                Ok(Expr::Lambda(Some(ty), body))
             }
-            RawExpr::Let(ident, binding, body) => {
+            RawExpr::Let(false, ident, binding, body) => {
                 let binding = Box::new(self.check(*binding)?);
                 self.idents.push(ident);
                 let body = Box::new(self.check(*body)?);
-                Ok(Expr::Let(binding, body))
+                Ok(Expr::Let(false, binding, body))
+            }
+            RawExpr::Let(true, ident, binding, body) => {
+                self.idents.push(ident);
+                let binding = Box::new(self.check(*binding)?);
+                let body = Box::new(self.check(*body)?);
+                Ok(Expr::Let(true, binding, body))
             }
             RawExpr::Literal(v) => Ok(Expr::Literal(v)),
             RawExpr::IfThenElse(cond, thn, els) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 use crate::ast::{BinaryOp, Expr};
@@ -11,50 +12,75 @@ pub enum Type {
     Bool,
     Num,
     Unit,
+    UnificationVar(usize),
 }
 
 pub(crate) struct TypeChecker {
     typing_env: Env<Type>,
+    next_unif_var: usize,
+    unif_table: HashMap<usize, Type>,
 }
 
 impl TypeChecker {
     pub(crate) fn new() -> Self {
         let typing_env = Env::new();
-        TypeChecker { typing_env }
+        let next_unif_var = 0;
+        let unif_table = Default::default();
+        TypeChecker { typing_env, next_unif_var, unif_table }
     }
 
-    pub(crate) fn check(&mut self, e: &Expr) -> Result<Type, TypeError> {
+    pub(crate) fn infer(&mut self, e: &Expr) -> Result<Type, TypeError> {
         use Expr::*;
 
         match e {
             App(fnc, a) => {
-                let fn_ty = self.check(fnc)?;
-                let a_ty = self.check(a)?;
+                let fn_ty = self.infer(fnc)?;
+                let a_ty = self.infer(a)?;
+
+                let in_var = self.new_unif_var();
+                let out_var = self.new_unif_var();
+                let fn_ty = self.unify(fn_ty, Type::Arrow(Box::new(in_var), Box::new(out_var)))?;
 
                 match fn_ty {
-                    Type::Arrow(in_ty, out_ty) if *in_ty == a_ty => Ok(*out_ty),
-                    _ => Err(TypeError::Mismatch),
+                    Type::Arrow(in_ty, out_ty) => {
+                        self.unify(*in_ty, a_ty)?;
+                        Ok(*out_ty)
+                    }
+                    _ => {
+                        Err(TypeError::Mismatch)
+                    }
                 }
             }
-            Lambda(ty, body) => {
+            Lambda(Some(ty), body) => {
                 self.typing_env.bind(ty.clone());
-                let ret_ty = self.check(body)?;
+                let ret_ty = self.infer(body)?;
                 self.typing_env.unbind();
                 Ok(Type::Arrow(Box::new(ty.clone()), Box::new(ret_ty)))
             }
-            Let(binding, body) => {
-                let binding_ty = self.check(binding)?;
+            Lambda(None, body) => {
+                let unif_var = self.new_unif_var();
+                self.typing_env.bind(unif_var);
+                self.infer(body)
+            }
+            Let(false, binding, body) => {
+                let binding_ty = self.infer(binding)?;
                 self.typing_env.bind(binding_ty);
-                self.check(body)
+                self.infer(body)
+            }
+            Let(true, _, body) => {
+                let unif_var = self.new_unif_var();
+                self.typing_env.bind(unif_var);
+                self.infer(body)
             }
             Literal(Val::Bool(_)) => Ok(Type::Bool),
             Literal(Val::Num(_)) => Ok(Type::Num),
             Literal(Val::Unit) => Ok(Type::Unit),
             Literal(Val::Closure { .. }) => unreachable!("We don't have closure literals."),
+            Literal(Val::Dummy) => unreachable!("We don't have dummy literals"),
             IfThenElse(cond, thn, els) => {
-                let cond_ty = self.check(cond)?;
-                let thn_ty = self.check(thn)?;
-                let els_ty = self.check(els)?;
+                let cond_ty = self.infer(cond)?;
+                let thn_ty = self.infer(thn)?;
+                let els_ty = self.infer(els)?;
                 if cond_ty == Type::Bool && thn_ty == els_ty {
                     Ok(thn_ty)
                 } else {
@@ -62,19 +88,56 @@ impl TypeChecker {
                 }
             }
             Op(l, op, r) => {
-                let l_ty = self.check(l)?;
-                let r_ty = self.check(r)?;
-                match (op, l_ty, r_ty) {
-                    (BinaryOp::Eq, _, _) => Ok(Type::Bool),
-                    (BinaryOp::And, Type::Bool, Type::Bool) => Ok(Type::Bool),
-                    (_, Type::Num, Type::Num) => Ok(Type::Num),
-                    _ => Err(TypeError::Mismatch),
+                let l_ty = self.infer(l)?;
+                let r_ty = self.infer(r)?;
+                match op {
+                    BinaryOp::Eq => Ok(Type::Bool),
+                    BinaryOp::And => {
+                        self.unify(l_ty, Type::Bool)?;
+                        self.unify(r_ty, Type::Bool)?;
+                        Ok(Type::Bool)
+                    },
+                    _ => {
+                        self.unify(l_ty, Type::Num)?;
+                        self.unify(r_ty, Type::Num)?;
+                        Ok(Type::Num)
+                    },
                 }
             }
             Var(i) => Ok(self
                 .typing_env
                 .lookup(*i)
                 .expect("Scope check should happen before typechecking")),
+        }
+    }
+
+    fn new_unif_var(&mut self) -> Type {
+        let t = Type::UnificationVar(self.next_unif_var);
+        self.next_unif_var += 1;
+        t
+    }
+
+    fn unify(&mut self, ty1: Type, ty2: Type) -> Result<Type, TypeError> {
+        match (ty1, ty2) {
+            (ty1, ty2) if ty1 == ty2 => Ok(ty1),
+            (Type::Arrow(from1, to1), Type::Arrow(from2, to2)) => {
+                let from = self.unify(*from1, *from2)?;
+                let to = self.unify(*to1, *to2)?;
+                Ok(Type::Arrow(Box::new(from), Box::new(to)))
+            },
+            (Type::UnificationVar(n), Type::UnificationVar(m)) if !self.unif_table.contains_key(&n) && !self.unif_table.contains_key(&m) => Ok(Type::UnificationVar(n)),
+            (t, Type::UnificationVar(n)) | (Type::UnificationVar(n), t) => {
+                match self.unif_table.get(&n) {
+                    None => {
+                        self.unif_table.insert(n, t.clone());
+                        Ok(t)
+                    }
+                    Some(t1) => self.unify(t, t1.clone()),
+                }
+            },
+            _ => {
+                Err(TypeError::Mismatch)
+            }
         }
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,11 +1,12 @@
-use std::fmt::Display;
+use std::{fmt::Display, cell::RefCell};
 
 use crate::{env::Env, error::EvaluationError, vm::Op};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Val {
     Bool(bool),
-    Closure { body: Vec<Op>, env: Env<Val> },
+    Closure { body: Vec<Op>, env: Env<RefCell<Val>> },
+    Dummy,
     Num(f64),
     Unit,
 }
@@ -15,6 +16,7 @@ impl Display for Val {
         match self {
             Val::Bool(b) => write!(f, "{}", b),
             Val::Closure { .. } => write!(f, "<function>"),
+            Val::Dummy => write!(f, "<dummy>"),
             Val::Num(n) => write!(f, "{}", n),
             Val::Unit => write!(f, "()"),
         }

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,11 +1,11 @@
 use std::{fmt::Display, cell::RefCell};
 
-use crate::{env::Env, error::EvaluationError, vm::Op};
+use crate::{env::Env, error::EvaluationError, vm::{stack::Stack, Op}};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Val {
     Bool(bool),
-    Closure { body: Vec<Op>, env: Env<RefCell<Val>> },
+    Closure { body: Stack<Op>, env: Env<RefCell<Val>> },
     Dummy,
     Num(f64),
     Unit,

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -1,6 +1,6 @@
 use crate::ast::Expr;
 
-use super::Op;
+use super::{Op, stack::Stack};
 
 enum CompilerMode {
     Normal,
@@ -11,18 +11,19 @@ enum CompilerMode {
 // see here: https://xavierleroy.org/mpri/2-4/machines.2up.pdf
 pub struct Compiler {
     mode: CompilerMode,
-    code: Vec<Op>,
+    code: Stack<Op>,
 }
 
 impl Compiler {
     pub fn new() -> Self {
         let mode = CompilerMode::Normal;
-        let code = Vec::new();
+        let code = Stack::new();
         Compiler { mode, code }
     }
 
     fn with_mode_and_ops<I: IntoIterator<Item=Op>>(mode: CompilerMode, i: I) -> Self {
-        let code = i.into_iter().collect();
+        let code: Vec<Op> = i.into_iter().collect();
+        let code = Stack::from_stacked_vec(code);
         Compiler { mode, code }
     }
 
@@ -43,7 +44,7 @@ impl Compiler {
     /// element of the vector is the first instruction to be computed. this is
     /// because most of the time we just pop the next instruction off, and
     /// popping from the tail of a vector is O(1).
-    pub fn compile(mut self, e: &Expr) -> Vec<Op> {
+    pub fn compile(mut self, e: &Expr) -> Stack<Op> {
         match self.mode {
             CompilerMode::Normal => self.push(e),
             CompilerMode::Tail => self.push_tail(e)
@@ -99,8 +100,8 @@ impl Compiler {
     fn push_tail(&mut self, e: &Expr) {
         match e {
             Expr::App(a, b) => {
-                self.push_tail(b);
-                self.push(a);
+                self.push_tail(a);
+                self.push(b);
             },
             Expr::Lambda(_, a) => {
                 self.push_tail(a);

--- a/src/vm/compiler.rs
+++ b/src/vm/compiler.rs
@@ -2,24 +2,39 @@ use crate::ast::Expr;
 
 use super::Op;
 
+enum CompilerMode {
+    Normal,
+    Tail
+}
+
+// Compilation scheme inspired by ZAM
+// see here: https://xavierleroy.org/mpri/2-4/machines.2up.pdf
 pub struct Compiler {
+    mode: CompilerMode,
     code: Vec<Op>,
 }
 
 impl Compiler {
     pub fn new() -> Self {
+        let mode = CompilerMode::Normal;
         let code = Vec::new();
-        Compiler { code }
+        Compiler { mode, code }
     }
 
-    fn for_closure() -> Self {
-        let code = vec![Op::Return()];
-        Compiler { code }
+    fn with_mode_and_ops<I: IntoIterator<Item=Op>>(mode: CompilerMode, i: I) -> Self {
+        let code = i.into_iter().collect();
+        Compiler { mode, code }
+    }
+
+    fn for_tail() -> Self {
+        Self::with_mode_and_ops(CompilerMode::Tail, None)
     }
 
     fn for_branch() -> Self {
-        let code = vec![Op::Join()];
-        Compiler { code }
+        Self::with_mode_and_ops(
+            CompilerMode::Normal,
+            Some(Op::Join())
+        )
     }
 
     /// compiles the syntax tree to a "bytecode" representation.
@@ -29,26 +44,39 @@ impl Compiler {
     /// because most of the time we just pop the next instruction off, and
     /// popping from the tail of a vector is O(1).
     pub fn compile(mut self, e: &Expr) -> Vec<Op> {
-        self.push(e);
+        match self.mode {
+            CompilerMode::Normal => self.push(e),
+            CompilerMode::Tail => self.push_tail(e)
+        }
         self.code
     }
 
     fn push(&mut self, e: &Expr) {
         match e {
             Expr::App(fnc, a) => {
+                let code = std::mem::take(&mut self.code);
                 self.code.push(Op::Apply());
-                self.push(a);
                 self.push(fnc);
+                self.push(a);
+                self.code.push(Op::PushRetAddr(code));
             }
             Expr::Lambda(_, body) => {
-                let body_ops = Compiler::for_closure().compile(body);
-                self.code.push(Op::Closure(body_ops));
+                let mut code = Compiler::for_tail().compile(body);
+                code.push(Op::Grab());
+                self.code.push(Op::Closure(code));
             }
-            Expr::Let(binding, body) => {
+            Expr::Let(false, binding, body) => {
                 self.code.push(Op::EndLet());
                 self.push(body);
-                self.code.push(Op::Let());
+                self.code.push(Op::Grab());
                 self.push(binding);
+            }
+            Expr::Let(true, binding, body) => {
+                self.code.push(Op::EndLet());
+                self.push(body);
+                self.code.push(Op::Update());
+                self.push(binding);
+                self.code.push(Op::Dummy());
             }
             Expr::Literal(v) => self.code.push(Op::Const(v.clone())),
             Expr::IfThenElse(cond, thn, els) => {
@@ -64,6 +92,34 @@ impl Compiler {
             }
             Expr::Var(i) => {
                 self.code.push(Op::Access(*i));
+            }
+        }
+    }
+
+    fn push_tail(&mut self, e: &Expr) {
+        match e {
+            Expr::App(a, b) => {
+                self.push_tail(b);
+                self.push(a);
+            },
+            Expr::Lambda(_, a) => {
+                self.push_tail(a);
+                self.code.push(Op::Grab());
+            }
+            Expr::Let(false, a, b) => {
+                self.push_tail(b);
+                self.code.push(Op::Grab());
+                self.push(a);
+            },
+            Expr::Let(true, a, b) => {
+                self.push_tail(b);
+                self.code.push(Op::Update());
+                self.push(a);
+                self.code.push(Op::Dummy());
+            }
+            a => {
+                self.code.push(Op::Return());
+                self.push(a);
             }
         }
     }

--- a/src/vm/stack.rs
+++ b/src/vm/stack.rs
@@ -13,6 +13,10 @@ impl<T> Stack<T> {
     pub fn pop(&mut self) -> Option<T> {
         self.0.pop()
     }
+
+    pub fn peek(&self) -> Option<&T> {
+        self.0.last()
+    }
 }
 
 impl<T: PartialEq> PartialEq for Stack<T> {

--- a/src/vm/stack.rs
+++ b/src/vm/stack.rs
@@ -1,9 +1,28 @@
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Stack<T>(Vec<T>);
+
+impl<T> Default for Stack<T> {
+    fn default() -> Self {
+        Stack::new()
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Stack<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let stacked = self.0.iter().rev().collect::<Vec<_>>();
+        f.debug_tuple("Stack").field(&stacked).finish()
+    }
+}
 
 impl<T> Stack<T> {
     pub fn new() -> Stack<T> {
         Stack(vec![])
+    }
+
+    /// Creates a Stack from a Vec which is already "stacked".
+    /// i.e., the "first element" conceptually is at the end of the Vec.
+    pub fn from_stacked_vec(v: Vec<T>) -> Stack<T> {
+        Stack(v)
     }
 
     pub fn push(&mut self, value: T) {
@@ -11,7 +30,8 @@ impl<T> Stack<T> {
     }
 
     pub fn pop(&mut self) -> Option<T> {
-        self.0.pop()
+        let p = self.0.pop();
+        p
     }
 
     pub fn peek(&self) -> Option<&T> {


### PR DESCRIPTION
This implements recursive let bindings by moving the bytecode representation to something closer to OCaml's "Zinc Abstract Machine".